### PR TITLE
Fixes

### DIFF
--- a/src/biotech/ui/BioSpawnerDialog.java
+++ b/src/biotech/ui/BioSpawnerDialog.java
@@ -11,6 +11,7 @@ import arc.util.*;
 import biotech.world.blocks.enviroment.BiologicalStaticSpawner.*;
 import mindustry.content.*;
 import mindustry.gen.*;
+import mindustry.input.*;
 import mindustry.type.*;
 import mindustry.ui.*;
 import mindustry.ui.dialogs.BaseDialog;
@@ -29,9 +30,7 @@ public class BioSpawnerDialog extends BaseDialog {
 
     public BioSpawnerDialog() {
         super("spawner");
-        clearChildren();
         addCloseListener();
-        makeButtonOverlay();
 
         setup();
 
@@ -63,7 +62,7 @@ public class BioSpawnerDialog extends BaseDialog {
     }
 
     private void setup(){
-        buttons.clearChildren();
+        buttons.clear();
         buttons.defaults().size(160f, 64f);
         buttons.button("@add", Icon.add, () -> {
             SpawnPlan p = new SpawnPlan(UnitTypes.dagger, 10 * Time.toSeconds, 1, StatusEffects.none, 0);
@@ -81,7 +80,6 @@ public class BioSpawnerDialog extends BaseDialog {
         cont.clear();
         cont.defaults();
         cont.table(a -> canvas = a.pane(spawnTable).size(a.getWidth(), a.getWidth()).scrollX(false).growX());
-
 
         spawnTable.clear();
         spawnTable.defaults();
@@ -140,18 +138,21 @@ public class BioSpawnerDialog extends BaseDialog {
     void effectPicker(SpawnPlan plan){
         BaseDialog dialog = new BaseDialog("@waves.edit");
         dialog.addCloseButton();
-        dialog.setFillParent(false);
 
         dialog.cont.pane( t -> {
             t.defaults().size(280f, 64f).pad(2f);
             int c = 0;
             for(StatusEffect item : content.statusEffects()){
+
+                StringBuilder tip = new StringBuilder(item.localizedName);
+                if(item.isModded()) tip.append("\n(").append(item.minfo.mod.meta.displayName()).append(")");
+
                 t.button(new TextureRegionDrawable((item == StatusEffects.none) ? Icon.none.getRegion() : item.uiIcon), Styles.flati, iconLarge, () -> {
                     plan.effect = item;
                     rebuild();
                     dialog.hide();
-                }).size(iconXLarge).scaling(Scaling.bounded).tooltip(item.localizedName);
 
+                }).size(iconXLarge).scaling(Scaling.bounded).tooltip(tip.toString());
                 if(++c % 6 == 0) t.row();
             }
         });
@@ -161,23 +162,29 @@ public class BioSpawnerDialog extends BaseDialog {
 
     void unitPicker(SpawnPlan plan){
         BaseDialog dialog = new BaseDialog("@waves.edit");
+        //For advance mapmakers and funnies
         dialog.addCloseButton();
-        dialog.setFillParent(false);
+        boolean advanced = Core.input.keyDown(Binding.boost);
+        
         dialog.cont.pane( t -> {
-            t.defaults().size(280f, 64f).pad(2f);
+            t.defaults().size(280f, 64f).pad(2f).scrollX(false);
             int c = 0;
             for(UnitType item : content.units()){
-                if(!item.unlockedNow() || item.isHidden() || !item.logicControllable) continue;
+                if(!advanced && (!item.unlockedNow() || item.isHidden() || !item.logicControllable)) continue;
+
+                StringBuilder tip = new StringBuilder(item.localizedName);
+                if(item.isModded()) tip.append("\n(").append(item.minfo.mod.meta.displayName()).append(")");
 
                 t.button(new TextureRegionDrawable(item.uiIcon), Styles.flati, iconLarge, () -> {
                     plan.unit = item;
                     rebuild();
                     dialog.hide();
-                }).size(iconXLarge).scaling(Scaling.bounded).tooltip(item.localizedName);
+                }).size(iconXLarge).scaling(Scaling.bounded).tooltip(tip.toString() );
 
                 if(++c % 6 == 0) t.row();
             }
         });
+
         dialog.show();
     }
 

--- a/src/biotech/world/blocks/enviroment/BiologicalStaticSpawner.java
+++ b/src/biotech/world/blocks/enviroment/BiologicalStaticSpawner.java
@@ -2,6 +2,7 @@ package biotech.world.blocks.enviroment;
 
 import arc.audio.*;
 import arc.graphics.g2d.*;
+import arc.math.*;
 import arc.scene.ui.layout.*;
 import arc.struct.*;
 import arc.util.io.*;
@@ -45,14 +46,17 @@ public class BiologicalStaticSpawner extends Prop {
 
     public class BiologicalStaticSpawnerBuild extends Building {
         SpawnPlan[] plans;
-        float[] timers;
+        public float[] timers;
 
         @Override
         public void update(){
             super.update();
 
             if(plans == null || plans.length == 0) return;
-            if(timers == null || timers.length != plans.length) timers = new float[plans.length];
+            if(timers == null || timers.length != plans.length){
+                timers = new float[plans.length];
+                for(int i = 0; i < plans.length; i++) timers[i] = plans[i].time;
+            }
 
             for(int i = 0; i < plans.length; i++){
                 timers[i]--;
@@ -63,10 +67,11 @@ public class BiologicalStaticSpawner extends Prop {
 
                 timers[i] = plan.time;
                 for(int j = 0; j < plan.amount; j++){
-                    Unit u = plan.unit.spawn(x, y);
+                    float fx = x + Mathf.random(-size, size), fy = y + Mathf.random(-size, size);
+                    Unit u = plan.unit.spawn(team, fx, fy);
                     u.apply(plan.effect, plan.effectTime);
 
-                    spawnFx.at(u.x, u.y, 0, u);
+                    spawnFx.at(fy , fy, 0, u);
                 }
                 spawnSound.at(x, y);
             }
@@ -94,7 +99,10 @@ public class BiologicalStaticSpawner extends Prop {
 
         @Override
         public void buildConfiguration(Table table){
-            table.button(Icon.pencil, Styles.cleari, () -> BioUI.spawner.show(plans, this::configure)).size(40);
+            table.button(Icon.pencil, Styles.cleari, () -> BioUI.spawner.show(plans, p ->{
+                configure(p);
+                timers = null;
+            } )).size(40);
         }
 
         @Override


### PR DESCRIPTION
- Fixed spawner not save/loading timers
- Fixed spawner Ui being behind the back buttons making bottom 4th entry be obstructed unless extra entry is added
- Updated spawner ui's unit dialog to show a modded unit mod name and fixed scrolling
- Fixed spawned units of the spawner not inheriting it's team
- Added spread to the spawner when pawning units to avoid clumping up groups